### PR TITLE
Update _package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -31,7 +31,7 @@
         "jshint-stylish": "0.2.0",<% } %>
         "grunt-contrib-copy": "0.5.0",
         "grunt-contrib-uglify": "0.4.0",<% if (cssOption === 'SASS') { %>
-        "grunt-sass": "0.12.1",<% } %><% if (cssOption === 'LESS') { %>
+        "grunt-sass": "0.13.0",<% } %><% if (cssOption === 'LESS') { %>
         "grunt-contrib-less": "0.11.0",<% } %>
         "grunt-open": "0.2.3",
         "grunt-svgmin": "0.4.0",


### PR DESCRIPTION
Increase required `grunt-sass` version up to [`0.13.0`](https://github.com/sindresorhus/grunt-sass/releases/tag/v0.13.0) so `yeogurt` will always support `.scss` indented (tabbed) syntax with minimum [`0.9.0`](https://github.com/sass/node-sass/releases/tag/v0.9.0) version of `node-sass` that requiring [`2.0`](https://github.com/sass/libsass/releases/tag/v2.0) version of `libsass`.

It's very important feature for me.
