### PR TITLE
Jade view sub-generator update

### DIFF
--- a/view/templates/view.jade
+++ b/view/templates/view.jade
@@ -19,7 +19,7 @@ extend base
 block template
     //- Define header block from base template
     block header
-        +header()
+        +h1()
 
     //- Provides template level styling
     #template-wrapper.template-wrapper<% if (name) { %>(class="<%= _.slugify(name.toLowerCase()) %>")<% } %>


### PR DESCRIPTION
The default component that is created is a mixin named h1. When the view sub generator is invoked the template refers to  a header and footer mixin that do not exist and break the Jade compilation. My pull request replaces the header mixin with the h1 mixin. I wonder if footer should also be replaced.
