### PR TITLE
Update main.sass

### DIFF
--- a/app/templates/client/styles/main.sass
+++ b/app/templates/client/styles/main.sass
@@ -77,42 +77,7 @@ $fa-font-path: "../bower_components/font-awesome/fonts"
 
 @import ../bower_components/foundation/scss/normalize
 
-@import ../bower_components/foundation/scss/foundation/components/grid
-@import ../bower_components/foundation/scss/foundation/components/accordion
-@import ../bower_components/foundation/scss/foundation/components/alert-boxes
-@import ../bower_components/foundation/scss/foundation/components/block-grid
-@import ../bower_components/foundation/scss/foundation/components/breadcrumbs
-@import ../bower_components/foundation/scss/foundation/components/button-groups
-@import ../bower_components/foundation/scss/foundation/components/buttons
-@import ../bower_components/foundation/scss/foundation/components/clearing
-@import ../bower_components/foundation/scss/foundation/components/dropdown
-@import ../bower_components/foundation/scss/foundation/components/dropdown-buttons
-@import ../bower_components/foundation/scss/foundation/components/flex-video
-@import ../bower_components/foundation/scss/foundation/components/forms
-@import ../bower_components/foundation/scss/foundation/components/inline-lists
-@import ../bower_components/foundation/scss/foundation/components/joyride
-@import ../bower_components/foundation/scss/foundation/components/keystrokes
-@import ../bower_components/foundation/scss/foundation/components/labels
-@import ../bower_components/foundation/scss/foundation/components/magellan
-@import ../bower_components/foundation/scss/foundation/components/orbit
-@import ../bower_components/foundation/scss/foundation/components/pagination
-@import ../bower_components/foundation/scss/foundation/components/panels
-@import ../bower_components/foundation/scss/foundation/components/pricing-tables
-@import ../bower_components/foundation/scss/foundation/components/progress-bars
-@import ../bower_components/foundation/scss/foundation/components/range-slider
-@import ../bower_components/foundation/scss/foundation/components/reveal
-@import ../bower_components/foundation/scss/foundation/components/side-nav
-@import ../bower_components/foundation/scss/foundation/components/split-buttons
-@import ../bower_components/foundation/scss/foundation/components/sub-nav
-@import ../bower_components/foundation/scss/foundation/components/switch
-@import ../bower_components/foundation/scss/foundation/components/tables
-@import ../bower_components/foundation/scss/foundation/components/tabs
-@import ../bower_components/foundation/scss/foundation/components/thumbs
-@import ../bower_components/foundation/scss/foundation/components/tooltips
-@import ../bower_components/foundation/scss/foundation/components/top-bar
-@import ../bower_components/foundation/scss/foundation/components/type
-@import ../bower_components/foundation/scss/foundation/components/offcanvas
-@import ../bower_components/foundation/scss/foundation/components/visibility<% } %>
+@import ../bower_components/foundation/scss/foundation<% } %>
 
 // Injects all imports files automatically (ex. _mypartial)
 // [injector]


### PR DESCRIPTION
no need to import all Foundation styles file by file because all imports are into `foundation/scss/foundation.scss`. and when it will be updated, you have not to update this strings anymore. (I just have Sass error because `switch` is not exists anymore into new Foundation version)