### PR TITLE
Updated version of grunt-sass from 0.14 to 0.16

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -56,7 +56,7 @@
         "jshint-stylish": "~1.0.0",<% } %>
         "grunt-contrib-copy": "~0.6.0",
         "grunt-contrib-uglify": "~0.6.0",<% if (cssOption === 'sass') { %>
-        "grunt-sass": "~0.14.0",<% } %><% if (cssOption === 'less') { %>
+        "grunt-sass": "~0.17.0",<% } %><% if (cssOption === 'less') { %>
         "grunt-contrib-less": "~0.11.0",<% } %><% if (cssOption === 'stylus') { %>
         "grunt-contrib-stylus": "~0.19.0",
         "nib": "1.0.3",<% } %>


### PR DESCRIPTION
Fixing Assertion failed: (val->IsString()) error which was a bug in sass compiler in 0.14 version.