### PR TITLE
Lodash needs to be a devDep, if 'react' not used

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -91,7 +91,8 @@
         "karma-jasmine": "~0.2.0",<% } else if (testFramework === 'mocha') { %>
         "karma-chai": "0.1.0",
         "karma-mocha": "~0.1.3",<% } %>
-        "karma": "~0.12.21",<% } %>
+        "karma": "~0.12.21",<% } %><% if (jsFramework != 'react') { %>
+        "lodash": "~2.4.1",<% } %>
         "time-grunt": "0.2.10",<% if (useDashboard) { %>
         "grunt-dashboard": "~0.3.0",<% } %>
         "bower": "~1.3.3",<% if (useFTP) { %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -91,7 +91,7 @@
         "karma-jasmine": "~0.2.0",<% } else if (testFramework === 'mocha') { %>
         "karma-chai": "0.1.0",
         "karma-mocha": "~0.1.3",<% } %>
-        "karma": "~0.12.21",<% } %><% if (jsFramework != 'react') { %>
+        "karma": "~0.12.21",<% } %><% if (jsFramework !== 'react') { %>
         "lodash": "~2.4.1",<% } %>
         "time-grunt": "0.2.10",<% if (useDashboard) { %>
         "grunt-dashboard": "~0.3.0",<% } %>


### PR DESCRIPTION
'lodash' is required to start any grunt task, if a project without 'react' has been set up. 

```
% yo yeogurt                             
                                    _   
  Welcome to                       | |  
  _   _  ___  ___   __ _ _   _ _ __| |_ 
 | | | |/ _ \/ _ \ / _` | | | | '__| __|
 | |_| |  __/ (_) | (_| | |_| | |  | |_ 
  \__, |\___|\___/ \__, |\__,_|_|   \__|
   __/ |            __/ |
  |___/            |___/                             


---- Project Info ----

? What would you like to name your project? Test
? Which version control software are you using (or plan to use)? Git

---- Server ----

? Would you like to use a Node + Express Server? No

---- Client ----

? Will this be a Single Page Application? No
? Which HTML preprocessor would you like to use? Jade
? Which JavaScript module library would you like to use? None
? What would you like to use to write styles? Sass
? What Sass syntax would you like to use ? Scss

---- Testing ----

? Will you be testing your client-side JavaScript? No

---- Documentation ----

? Would you like to document your Javascript with JSDoc? No
? Would you like to generate a styleguide with KSS (Knyle Style Sheets)? No
? Would you like to generate a dashboard for your site/app: No

---- Deployment ----

? Will you be deploying code to an FTP server? No
```
Results in:
```
% grunt
Loading "Gruntfile.js" tasks...ERROR
>> Error: Cannot find module 'lodash'

jit-grunt: Plugin for the "default" task not found.
If you have installed the plugin already, please setting the static mapping.
See https://github.com/shootaroo/jit-grunt#static-mappings

Warning: Task "default" failed. Use --force to continue.

Aborted due to warnings.


Execution Time (2015-01-14 20:06:18 UTC)
loading tasks  20ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 95%
Total 21ms
```
