### PR TITLE
remove `_` from sass import statements in grunt-injector task

### DIFF
--- a/app/templates/grunt/config/util/injector.js
+++ b/app/templates/grunt/config/util/injector.js
@@ -111,6 +111,7 @@ var taskConfig = function(grunt) {
             filePath = filePath.replace('/client/styles/', '');
           }<% } else { %>
           filePath = filePath.replace('/client/styles/', '');<% } %>
+          filePath = filePath.replace(/_/, '');
           <% if (sassSyntax === 'scss') { %>
           return '@import \'' + filePath.slice(0, -5) + '\';';<% } else { %>
           return '@import ' + filePath.slice(0, -5);<% } %>

--- a/app/templates/grunt/config/util/injector.js
+++ b/app/templates/grunt/config/util/injector.js
@@ -111,7 +111,7 @@ var taskConfig = function(grunt) {
             filePath = filePath.replace('/client/styles/', '');
           }<% } else { %>
           filePath = filePath.replace('/client/styles/', '');<% } %>
-          filePath = filePath.replace(/_/, '');
+          filePath = filePath.replace(/(\/)(_)/, '$1');
           <% if (sassSyntax === 'scss') { %>
           return '@import \'' + filePath.slice(0, -5) + '\';';<% } else { %>
           return '@import ' + filePath.slice(0, -5);<% } %>

--- a/app/templates/grunt/config/util/injector.js
+++ b/app/templates/grunt/config/util/injector.js
@@ -111,7 +111,7 @@ var taskConfig = function(grunt) {
             filePath = filePath.replace('/client/styles/', '');
           }<% } else { %>
           filePath = filePath.replace('/client/styles/', '');<% } %>
-          filePath = filePath.replace(/(\/)(_)/, '$1');
+          filePath = filePath.replace(/(\/)(_)([a-zA-z]+\.[A-Za-z]*)/, '$1$3');
           <% if (sassSyntax === 'scss') { %>
           return '@import \'' + filePath.slice(0, -5) + '\';';<% } else { %>
           return '@import ' + filePath.slice(0, -5);<% } %>


### PR DESCRIPTION
This removes the `_` from the partial sass imports when injecting the statements into sass files.