### PR TITLE
Can't access server from VM environment

### DIFF
--- a/app/templates/grunt/config/server/connect.js
+++ b/app/templates/grunt/config/server/connect.js
@@ -9,7 +9,7 @@ var taskConfig = function(grunt) {
     options: {
       port: 9010,
       livereload: 35729,
-      hostname: '127.0.0.1'
+      hostname: '0.0.0.0'
     },
     server: {
       options: {


### PR DESCRIPTION
When running yeogurt from a vm the connect server is started on 127.0.0.1.
This only allows for access from with in the VM and not from the Host OS.

This change will allow access from the HOST OS but also to any other 3rd
party hitting you're `<IPADDRESS>:9010`.

@larsonjj if this fix is too permissive let me know