### PR TITLE
Added guide for changing root directory

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ This section contains information on how to implement extra libraries and plugin
 
 ## Deployment
 - [FTP](ftp.md)
+- [Change root directory](change-root-dir.md)
 
 ###Can't find a guide for your favorite library or plugin?
 

--- a/docs/guides/change-root-dir.md
+++ b/docs/guides/change-root-dir.md
@@ -1,6 +1,8 @@
 # Changing the root directory
 Need to change the location of a Yeogurt site from `/` to `/subdir/`? Follow this guide to set up your project.
 
+*Note: This guide has only been tested for a Yeogurt project using the static site generator. Other setups may vary.
+
 ## Steps
 
 ### 1. Change location of `.tmp` folder

--- a/docs/guides/change-root-dir.md
+++ b/docs/guides/change-root-dir.md
@@ -1,0 +1,63 @@
+# Changing the root directory
+Need to change the location of a Yeogurt site from `/` to `/subdir/`? Follow this guide to set up your project.
+
+## Steps
+
+### 1. Change location of `.tmp` folder
+In `/Gruntfile.js` change the following lines of code from
+```
+var config = {
+  client: 'client',
+  tmp: '.tmp',
+  dist: 'dist',
+  server: 'server'
+};
+```
+to
+```
+var config = {
+  client: 'client',
+  tmp: '.tmp/subdir',
+  dist: 'dist',
+  server: 'server'
+};
+```
+
+### 2. Change Grunt Connect settings
+In `/grunt/config/server/connect.js` edit the `grunt.config.set()` function so that it looks like this:
+```
+grunt.config.set('connect', {
+    options: {
+      port: 9010,
+      livereload: 35729,
+      hostname: '127.0.0.1'
+    },
+    server: {
+      options: {
+        open: 'http://127.0.0.1:9010/subdir',
+        base: '<%= yeogurt.client %>/',
+        middleware: function(connect) {
+          return [
+            connect.static('.tmp'),
+            connect().use('/subdir/bower_components', connect.static('./client/bower_components')),
+            connect().use('/subdir/images', connect.static('./client/images')),
+            connect.static('client')
+          ];
+        }
+      }
+    },
+    dist: {
+      options: {
+        open: 'http://127.0.0.1:9010/subdir',
+        base: '<%= yeogurt.dist %>/',
+        middleware: function(connect) {
+          return [
+            connect.static('dist'),
+            connect().use('/subdir/', connect.static('dist'))
+          ];
+        },
+        livereload: false
+      }
+    }
+  });
+  ```


### PR DESCRIPTION
I've created a guide for changing the default root directory of a Yeogurt project from `/` to `/subdir`. This has only been tested on a static site, but the process may be similar for other setups. Please review language of guide and make recommendations for tweaking.