### PR TITLE
changed autoprefixer config in build task

### DIFF
--- a/app/templates/grunt/tasks/build.js
+++ b/app/templates/grunt/tasks/build.js
@@ -17,7 +17,7 @@ var taskConfig = function(grunt) {
     'concat:generated',<% if (jsFramework === 'angular') { %>
     'ngAnnotate',<% } %>
     'cssmin',
-    'autoprefixer:server',
+    'autoprefixer:dist',
     'usemin',
     'htmlmin:dist',
     'uglify',


### PR DESCRIPTION
Hello,

When I built my yeogurt application I noticed that my css hasn't been autoprefixed. 
Then I noticed that in *build.js* file there is 

    grunt.registerTask('build', 'Build a production ready version of your site.', [
      ...
      'autoprefixer:server',
      ...
    ]);

Changed to `autoprefixer:dist`, the css was autoprefixed properly.

Cheers
