### PR TITLE
Fixes grunt-jsdoc npm version bug.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -59,7 +59,7 @@
     "minifyify": "~5.0.0",
     "grunt-browserify": "~3.2.0",<% } %>
     "grunt-usemin": "2.1.1",<% if (useJsdoc) { %>
-    "grunt-jsdoc": "beta",<% } %>
+    "grunt-jsdoc": "0.6.7",<% } %>
     "grunt-concurrent": "~1.0.0",<% if (jsTemplate === 'underscore') { %>
     "grunt-contrib-jst": "~0.6.0",<% } else if (jsTemplate === 'handlebars') { %>
     "grunt-contrib-handlebars": "~0.9.0",<% } else if (jsFramework === 'react') { %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-yeogurt",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "A “Choose your own adventure” generator for creating static sites and single page applications. Helps you harness the power of your favorite tools: Angular, React + Flux, Backbone, Jade, Swig, Express, Grunt and much more!",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
`grunt-jsdoc` version `beta` was removed from the npm registry. This fixes the missing dependency error.