### PR TITLE
Fixed issue where updating JS file doesn't re-bundle

### DIFF
--- a/app/templates/gulp/browserify.js
+++ b/app/templates/gulp/browserify.js
@@ -73,7 +73,7 @@ export default function(gulp, plugins, args, config, taskTarget) {
       };
 
       if (!args.production) {
-        bundler.on('update', browserifyTask); // on any dep update, runs the bundler
+        bundler.on('update', rebundle); // on any dep update, runs the bundler
         bundler.on('log', plugins.util.log); // output build logs to terminal
       }
       return rebundle();


### PR DESCRIPTION
Updated gulpfile to call the rebundle function when an update occurs to a JS file via browserify