### PR TITLE
Bugfix: inserting data into nunjucks

### DIFF
--- a/app/templates/gulp/nunjucks.js
+++ b/app/templates/gulp/nunjucks.js
@@ -40,12 +40,10 @@ export default function(gulp, plugins, args, config, taskTarget, browserSync) {
     .pipe(plugins.changed(dest))
     .pipe(plugins.plumber())
     .pipe(plugins.data({
-      data: {
-        config: config,
-        debug: true,
-        site: {
-          data: siteData
-        }
+      config: config,
+      debug: true,
+      site: {
+        data: siteData[dirs.data]
       }
     }))
     .pipe(nunjucks({


### PR DESCRIPTION
Fixes data insertion for the nunjucks rendering engine. Also corrects the given arguments, now it corresponds to the documentation and the jade render engine.