### PR TITLE
Create sensible defaults for module generator

### DIFF
--- a/module/templates/module.jade
+++ b/module/templates/module.jade
@@ -1,6 +1,6 @@
 mixin <%= _.slugify(name.toLowerCase()) %>(spec)
   - spec = spec || {}
-  - spec.class = spec.class || ''
+  - spec._class = spec._class || ''
 
-  div(class=spec.class)&attributes(attributes)
+  div(class=spec._class)&attributes(attributes)
     p This is an example paragraph for the <%= _.slugify(name.toLowerCase()) %> module

--- a/module/templates/module.jade
+++ b/module/templates/module.jade
@@ -1,6 +1,6 @@
 mixin <%= _.slugify(name.toLowerCase()) %>(spec)
   - spec = spec || {}
-  - spec._class = spec._class || ''
+  - spec.__class = spec.__class || ''
 
-  div(class=spec._class)&attributes(attributes)
+  div(class=spec.__class)&attributes(attributes)
     p This is an example paragraph for the <%= _.slugify(name.toLowerCase()) %> module

--- a/module/templates/module.jade
+++ b/module/templates/module.jade
@@ -1,5 +1,6 @@
-mixin <%= _.slugify(name.toLowerCase()) %>(config)
-  - var _config = config || {}
+mixin <%= _.slugify(name.toLowerCase()) %>(spec)
+  - spec = spec || {}
+  - spec.class = spec.class || ''
 
-  div.<%= _.slugify(name.toLowerCase()) %>
+  div(class=spec.class)&attributes(attributes)
     p This is an example paragraph for the <%= _.slugify(name.toLowerCase()) %> module


### PR DESCRIPTION
* Changes `config` to `spec` and sets up default class for modules.
* Adds `&attributes` to created element