### PR TITLE
Allow subdirectories in yeogurt:module subgenerator

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -49,6 +49,11 @@ ModuleGenerator.prototype.ask = function ask() {
     path.join(directories.source, directories.modules) :
     'src' + '/_modules';
 
+  if(this.name.split('/').length > 1) {
+    moduleDir += '/' + this.name.split('/').slice(0, -1).join('/');
+  }
+  this.name = this.name.split('/').slice(-1)[0];
+
   this.moduleFile = path.join(
     moduleDir,
     this._.slugify(this.name.toLowerCase()),

--- a/test/subgenerators/module.test.js
+++ b/test/subgenerators/module.test.js
@@ -122,6 +122,40 @@ describe('Static Site module sub-generator', function() {
               });
             });
           });
+          it('creates subdirectories', function(done) {
+            // Filename
+            var module = 'customdir/mymodule';
+
+            var filesToTest = [
+              'src/_modules/' + module + '/tests/' + module + '.test.js',
+              'src/_modules/' + module + '/' + module + '.js',
+              'src/_modules/' + module + '/' + module + '.jade',
+              'src/_modules/' + module + '/' + module + '.sass'
+            ];
+            var fileContentToTest = [
+              ['src/_modules/' + module + '/' + module + '.js', /export/i],
+              ['src/_modules/' + module + '/tests/' + module + '.test.js', /describe/i]
+            ];
+
+            helpers.mockPrompt(this.app, {
+              htmlOption: 'jade',
+              testFramework: 'jasmine',
+              jsOption: 'browserify',
+              cssOption: 'sass',
+              sassSyntax: 'sass'
+            });
+
+            this.app.run([], function() {
+              createSubGenerator('module', module, {path: '../../../'}, {
+                // mock prompt data
+                moduleFile: 'src/_modules'
+              }, function() {
+                assert.file(filesToTest);
+                assert.fileContent(fileContentToTest);
+                done();
+              });
+            });            
+          });
         });
       });
     });

--- a/test/subgenerators/module.test.js
+++ b/test/subgenerators/module.test.js
@@ -125,16 +125,17 @@ describe('Static Site module sub-generator', function() {
           it('creates subdirectories', function(done) {
             // Filename
             var module = 'customdir/mymodule';
+            var moduleName = 'mymodule';
 
             var filesToTest = [
-              'src/_modules/' + module + '/tests/' + module + '.test.js',
-              'src/_modules/' + module + '/' + module + '.js',
-              'src/_modules/' + module + '/' + module + '.jade',
-              'src/_modules/' + module + '/' + module + '.sass'
+              'src/_modules/' + module + '/tests/' + moduleName + '.test.js',
+              'src/_modules/' + module + '/' + moduleName + '.js',
+              'src/_modules/' + module + '/' + moduleName + '.jade',
+              'src/_modules/' + module + '/' + moduleName + '.sass'
             ];
             var fileContentToTest = [
-              ['src/_modules/' + module + '/' + module + '.js', /export/i],
-              ['src/_modules/' + module + '/tests/' + module + '.test.js', /describe/i]
+              ['src/_modules/' + module + '/' + moduleName + '.js', /export/i],
+              ['src/_modules/' + module + '/tests/' + moduleName + '.test.js', /describe/i]
             ];
 
             helpers.mockPrompt(this.app, {


### PR DESCRIPTION
This allows subdirectories to be specified in the yeogurt:module subgenerator
so that paths entered will not be slugified, but instead added to the moduleDir
path.

ex. `yo yeogurt:module cool/modules/button` will now add files to
"src/_modules/cool/modules/button" instead of "src/_modules/cool-modules-button".

This update also works with Atomic flags so that the atomic subdirectory will be
appended to the end of the specified subdirectory.

ex. `yo yeogurt:module cool/modules/button --atomic=atom` will create a module at
"src/_modules/cool/modules/atoms/button".