### PR TITLE
Allow for partial config files

### DIFF
--- a/app/generator/config/save.js
+++ b/app/generator/config/save.js
@@ -5,11 +5,7 @@
 'use strict';
 
 var saveConfig = function saveConfig() {
-  // If user chooses to use exsiting yo-rc file, then skip prompts
-  if (!this.existingConfig) {
-    // Create .yo-rc.json file
-    this.config.set('config', this.answers);
-  }
+  this.config.set('config', this.answers);
 
   this.config.set('version', this.pkg.version);
   this.config.forceSave();

--- a/app/generator/prompts/client.js
+++ b/app/generator/prompts/client.js
@@ -106,7 +106,7 @@ var clientPrompts = function clientPrompts() {
     if(!configPrompts.length) return;
   }
   else {
-    configPrompts = _.values(prompts);
+    configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 
   var cb = this.async();

--- a/app/generator/prompts/client.js
+++ b/app/generator/prompts/client.js
@@ -4,72 +4,116 @@
 
 'use strict';
 
+var _ = require('lodash');
+
 var clientPrompts = function clientPrompts() {
+  this.clientPrompts = {};
+  var prompts = {
+    htmlOption: {
+      type: 'list',
+      name: 'htmlOption',
+      message: 'Which ' + 'HTML preprocessor'.blue + ' would you like to use?',
+      choices: ['Jade', 'Nunjucks'],
+      filter: function(val) {
+        var filterMap = {
+          'Jade': 'jade',
+          'Nunjucks': 'nunjucks'
+        };
+
+        return filterMap[val];
+      }
+    },
+    jsPreprocessor: {
+      type: 'list',
+      name: 'jsPreprocessor',
+      message: 'What ' + 'JavaScript preprocessor'.blue + ' would you like to use?',
+      choices: ['None', 'ES6 (Using Babel)'],
+      filter: function(val) {
+        var filterMap = {
+          'None': 'none',
+          'ES6 (Using Babel)': 'es6'
+        };
+
+        return filterMap[val];
+      }
+    },
+    cssOption: {
+      type: 'list',
+      name: 'cssOption',
+      message: 'What would you like to use to ' + 'write styles'.blue + '?',
+      choices: ['Sass', 'Less', 'Stylus'],
+      filter: function(val) {
+        var filterMap = {
+          'Sass': 'sass',
+          'Less': 'less',
+          'Stylus': 'stylus'
+        };
+
+        return filterMap[val];
+      }
+    },
+    sassSyntax: {
+      when: function(answers) {
+        return answers.cssOption === 'sass';
+      },
+      type: 'list',
+      name: 'sassSyntax',
+      message: 'What ' + 'Sass syntax'.blue + ' would you like to use ?',
+      choices: ['Scss', 'Sass'],
+      filter: function(val) {
+        var filterMap = {
+          'Scss': 'scss',
+          'Sass': 'sass'
+        };
+
+        return filterMap[val];
+      }
+    }
+  };
+  var configPrompts = [];
+
   if (this.existingConfig) {
-    return;
+    var config = this.config.get('config');
+
+    if (config.htmlOption) {
+      this.clientPrompts.htmlOption = config.htmlOption;
+    }
+    else {
+      configPrompts.push(prompts.htmlOption);
+    }
+
+    if (config.jsPreprocessor) {
+      this.clientPrompts.jsPreprocessor = config.jsPreprocessor;
+    }
+    else {
+      configPrompts.push(prompts.jsPreprocessor);
+    }
+
+    if (config.cssOption) {
+      this.clientPrompts.cssOption = config.cssOption;
+    }
+    else {
+      configPrompts.push(cssOption);
+    }
+
+    if (config.sassSyntax) {
+      this.clientPrompts.sassSyntax = config.sassSyntax;
+    }
+    else {
+      configPrompts.push(sassSyntax);
+    }
+
+    if(!configPrompts.length) return;
+  }
+  else {
+    configPrompts = _.values(prompts);
   }
 
   var cb = this.async();
 
   this.log('\n---- ' + 'Client'.red.underline + ' ----\n');
 
-  this.prompt([{
-    type: 'list',
-    name: 'htmlOption',
-    message: 'Which ' + 'HTML preprocessor'.blue + ' would you like to use?',
-    choices: ['Jade', 'Nunjucks'],
-    filter: function(val) {
-      var filterMap = {
-        'Jade': 'jade',
-        'Nunjucks': 'nunjucks'
-      };
-
-      return filterMap[val];
-    }
-  }, {
-    type: 'list',
-    name: 'jsPreprocessor',
-    message: 'What ' + 'JavaScript preprocessor'.blue + ' would you like to use?',
-    choices: ['None', 'ES6 (Using Babel)'],
-    filter: function(val) {
-      var filterMap = {
-        'None': 'none',
-        'ES6 (Using Babel)': 'es6'
-      };
-
-      return filterMap[val];
-    }
-  }, {
-    type: 'list',
-    name: 'cssOption',
-    message: 'What would you like to use to ' + 'write styles'.blue + '?',
-    choices: ['Sass', 'Less', 'Stylus'],
-    filter: function(val) {
-      var filterMap = {
-        'Sass': 'sass',
-        'Less': 'less',
-        'Stylus': 'stylus'
-      };
-
-      return filterMap[val];
-    }
-  }, {
-    when: function(answers) {
-      return answers.cssOption === 'sass';
-    },
-    type: 'list',
-    name: 'sassSyntax',
-    message: 'What ' + 'Sass syntax'.blue + ' would you like to use ?',
-    choices: ['Scss', 'Sass'],
-    filter: function(val) {
-      var filterMap = {
-        'Scss': 'scss',
-        'Sass': 'sass'
-      };
-
-      return filterMap[val];
-    }
-  }], function(answers) {
+  this.prompt(configPrompts, function(answers) {
     this.clientPrompts = answers;
 
     cb();

--- a/app/generator/prompts/client.js
+++ b/app/generator/prompts/client.js
@@ -106,6 +106,7 @@ var clientPrompts = function clientPrompts() {
     if(!configPrompts.length) return;
   }
   else {
+    this.clientPrompts = this.options;
     configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 

--- a/app/generator/prompts/project.js
+++ b/app/generator/prompts/project.js
@@ -31,7 +31,7 @@ var projectPrompts = function projectPrompts() {
     if (!configPrompts.length) return;
   }
   else {
-    configPrompts = _.values(prompts);
+    configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 
   var cb = this.async();

--- a/app/generator/prompts/project.js
+++ b/app/generator/prompts/project.js
@@ -31,6 +31,7 @@ var projectPrompts = function projectPrompts() {
     if (!configPrompts.length) return;
   }
   else {
+    this.projectPrompts = this.options;
     configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 

--- a/app/generator/prompts/project.js
+++ b/app/generator/prompts/project.js
@@ -4,21 +4,41 @@
 
 'use strict';
 
+var _ = require('lodash');
+
 var projectPrompts = function projectPrompts() {
+  this.projectPrompts = {};
+  var prompts = {
+    projectName: {
+        type: 'input',
+        name: 'projectName',
+        message: 'What would you like to' + ' name your project'.blue + '?',
+        default: 'Sample'
+      }
+  };
+  var configPrompts = [];
+
   if (this.existingConfig) {
-    return;
+    var config = this.config.get('config');
+
+    if (config.projectName) {
+      this.projectPrompts.projectName = config.projectName;
+    }
+    else {
+      configPrompts.push(prompts.projectName);
+    }
+
+    if (!configPrompts.length) return;
+  }
+  else {
+    configPrompts = _.values(prompts);
   }
 
   var cb = this.async();
 
   this.log('\n---- ' + 'Project Info'.red.underline + ' ----\n');
 
-  this.prompt([{
-    type: 'input',
-    name: 'projectName',
-    message: 'What would you like to' + ' name your project'.blue + '?',
-    default: 'Sample'
-  }], function(answers) {
+  this.prompt(configPrompts, function(answers) {
     this.projectPrompts = answers;
 
     cb();

--- a/app/generator/prompts/testing.js
+++ b/app/generator/prompts/testing.js
@@ -40,7 +40,7 @@ var testingPrompts = function testingPrompts() {
     if(!configPrompts.length) return;
   }
   else {
-    configPrompts = _.values(prompts);
+    configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 
   var cb = this.async();

--- a/app/generator/prompts/testing.js
+++ b/app/generator/prompts/testing.js
@@ -34,12 +34,13 @@ var testingPrompts = function testingPrompts() {
       this.testingPrompts = config.testFramework;
     }
     else {
-      configPrompts.push(prompts.testFramework)
+      configPrompts.push(prompts.testFramework);
     }
 
     if(!configPrompts.length) return;
   }
   else {
+    this.testingPrompts = this.options;
     configPrompts = _.values(_.omit(prompts, _.keys(this.options)));
   }
 

--- a/app/generator/prompts/testing.js
+++ b/app/generator/prompts/testing.js
@@ -4,30 +4,50 @@
 
 'use strict';
 
+var _ = require('lodash');
+
 var testingPrompts = function testingPrompts() {
+  this.testingPrompts = {};
+  var prompts = {
+    testFramework: {
+      type: 'list',
+      name: 'testFramework',
+      message: 'Which JavaScript ' + 'testing framework'.blue + ' would you like to use?',
+      choices: ['Jasmine', 'Mocha', 'None'],
+      filter: function(val) {
+        var filterMap = {
+          'Jasmine': 'jasmine',
+          'Mocha': 'mocha',
+          'None': 'none'
+        };
+
+        return filterMap[val];
+      }
+    }
+  };
+  var configPrompts = [];
+
   if (this.existingConfig) {
-    return;
+    var config = this.config.get('config');
+
+    if (config.testFramework) {
+      this.testingPrompts = config.testFramework;
+    }
+    else {
+      configPrompts.push(prompts.testFramework)
+    }
+
+    if(!configPrompts.length) return;
+  }
+  else {
+    configPrompts = _.values(prompts);
   }
 
   var cb = this.async();
 
   this.log('\n---- ' + 'Testing'.red.underline + ' ----\n');
 
-  this.prompt([{
-    type: 'list',
-    name: 'testFramework',
-    message: 'Which JavaScript ' + 'testing framework'.blue + ' would you like to use?',
-    choices: ['Jasmine', 'Mocha', 'None'],
-    filter: function(val) {
-      var filterMap = {
-        'Jasmine': 'jasmine',
-        'Mocha': 'mocha',
-        'None': 'none'
-      };
-
-      return filterMap[val];
-    }
-  }], function(answers) {
+  this.prompt(configPrompts, function(answers) {
     this.testingPrompts = answers;
 
     cb();


### PR DESCRIPTION
This change allows Yeogurt to read incomplete .yo-rc.json files. If only some of the options are specified and the user selects 'Yes' to the "Use existing config" prompt, then Yeogurt will skip the steps that are already specified in the partial .yo-rc.json and prompt for the steps that are missing.

This is useful for generator composability, such as when an external generator includes Yeogurt and may pass it some predetermined setup options, but leave others up to the user to decide.
