### PR TITLE
Improve error handling when compiling js, sass/less/stylus

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,6 +18,7 @@
     "wrench": "~1.5.8",
     "gulp-plumber": "~1.0.1",
     "gulp-changed": "~1.3.0",
+    "gulp-notify": "^2.2.0",
     "gulp-rename": "~1.2.2",
     "gulp-uglify": "~1.5.1",
     "del": "~2.2.0",

--- a/app/templates/gulp/es5/browserify.js
+++ b/app/templates/gulp/es5/browserify.js
@@ -42,16 +42,17 @@ module.exports = function(gulp, plugins, args, config, taskTarget, browserSync) 
             plugins.util.log(
               plugins.util.colors.red('Browserify compile error:'),
               '\n',
-              err,
+              err.stack,
               '\n'
             );
             this.emit('end');
           })
+          .on('error', plugins.notify.onError(config.defaultNotification))
           .pipe(vsource(entry))
           .pipe(buffer())
           .pipe(plugins.sourcemaps.init({loadMaps: true}))
             .pipe(gulpif(args.production, plugins.uglify()))
-            .on('error', plugins.util.log)
+            .on('error', plugins.notify.onError(config.defaultNotification))
           .pipe(plugins.rename(function(filepath) {
             // Remove 'source' directory as well as prefixed folder underscores
             // Ex: 'src/_scripts' --> '/scripts'

--- a/app/templates/gulp/es5/less.js
+++ b/app/templates/gulp/es5/less.js
@@ -20,6 +20,7 @@ module.exports = function(gulp, plugins, args, config, taskTarget, browserSync) 
           path.join(dirs.source, dirs.modules)
         ]
       }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(filepath) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulp/es5/sass.js
+++ b/app/templates/gulp/es5/sass.js
@@ -21,7 +21,8 @@ module.exports = function(gulp, plugins, args, config, taskTarget, browserSync) 
           path.join(dirs.source, dirs.styles),
           path.join(dirs.source, dirs.modules)
         ]
-      }).on('error', plugins.sass.logError))
+      }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(filepath) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulp/es5/stylus.js
+++ b/app/templates/gulp/es5/stylus.js
@@ -18,6 +18,7 @@ module.exports = function(gulp, plugins, args, config, taskTarget, browserSync) 
         compress: true,
         'include css': true
       }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(filepath) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulp/es6/browserify.js
+++ b/app/templates/gulp/es6/browserify.js
@@ -44,16 +44,17 @@ export default function(gulp, plugins, args, config, taskTarget, browserSync) {
             plugins.util.log(
               plugins.util.colors.red('Browserify compile error:'),
               '\n',
-              err,
+              err.stack,
               '\n'
             );
             this.emit('end');
           })
+          .on('error', plugins.notify.onError(config.defaultNotification))
           .pipe(vsource(entry))
           .pipe(buffer())
           .pipe(plugins.sourcemaps.init({loadMaps: true}))
             .pipe(gulpif(args.production, plugins.uglify()))
-            .on('error', plugins.util.log)
+            .on('error', plugins.notify.onError(config.defaultNotification))
           .pipe(plugins.rename(function(filepath) {
             // Remove 'source' directory as well as prefixed folder underscores
             // Ex: 'src/_scripts' --> '/scripts'

--- a/app/templates/gulp/es6/less.js
+++ b/app/templates/gulp/es6/less.js
@@ -20,6 +20,7 @@ export default function(gulp, plugins, args, config, taskTarget, browserSync) {
           path.join(dirs.source, dirs.modules)
         ]
       }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(path) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulp/es6/sass.js
+++ b/app/templates/gulp/es6/sass.js
@@ -21,7 +21,8 @@ export default function(gulp, plugins, args, config, taskTarget, browserSync) {
           path.join(dirs.source, dirs.styles),
           path.join(dirs.source, dirs.modules)
         ]
-      }).on('error', plugins.sass.logError))
+      }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(path) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulp/es6/stylus.js
+++ b/app/templates/gulp/es6/stylus.js
@@ -18,6 +18,7 @@ export default function(gulp, plugins, args, config, taskTarget, browserSync) {
         compress: true,
         'include css': true
       }))
+      .on('error', plugins.notify.onError(config.defaultNotification))
       .pipe(plugins.postcss([autoprefixer({browsers: ['last 2 version', '> 5%', 'safari 5', 'ios 6', 'android 4']})]))
       .pipe(plugins.rename(function(path) {
         // Remove 'source' directory as well as prefixed folder underscores

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -14,7 +14,17 @@ const plugins = gulpLoadPlugins();<% if (testFramework !== 'none') { %>
 // Create karma server
 const KarmaServer = require('karma').Server;<% } %>
 
-let config = pjson.config;
+const defaultNotification = function(err) {
+    return {
+        subtitle: err.plugin,
+        message: err.message,
+        sound: 'Funk',
+        onLast: true,
+    };
+};
+
+let config = Object.assign({}, pjson.config, defaultNotification);
+
 let args = minimist(process.argv.slice(2));
 let dirs = config.directories;
 let taskTarget = args.production ? dirs.destination : dirs.temporary;

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -15,6 +15,14 @@ var plugins = gulpLoadPlugins();<% if (testFramework !== 'none') { %>
 var KarmaServer = require('karma').Server;<% } %>
 
 var config = pjson.config;
+config.defaultNotification = function(err) {
+    return {
+        subtitle: err.plugin,
+        message: err.message,
+        sound: 'Funk',
+        onLast: true,
+    };
+};
 var args = minimist(process.argv.slice(2));
 var dirs = config.directories;
 var taskTarget = args.production ? dirs.destination : dirs.temporary;


### PR DESCRIPTION
* Add [gulp-notify](https://www.npmjs.com/package/gulp-notify) in order to raise awareness on errors during compilation progress
* On browserify error, print `err.stack` instead of `err` as the latter does not include a decent error description