### PR TITLE
Fix wrong es6 template, and .test.js import errors.

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -103,46 +103,22 @@ ModuleGenerator.prototype.files = function files() {
     return;
   }
 
-  if (this.htmlOption === 'jade') {
-    this.template('module.jade', this.moduleFile + '.jade');
-    if (this.jsPreprocessor === 'none') {
-      this.template('module.js', this.moduleFile + '.js');
-    }
-    else {
-      this.template('module.es6.js', this.moduleFile + '.js');
-    }
-    if (this.testFramework !== 'none') {
-      if (this.jsPreprocessor === 'none') {
-        this.template('module.test.js', this.testFile + '.test.js');
-      }
-      else {
-        this.template('module.test.es6.js', this.testFile + '.test.js');
-      }
-    }
-  }
-  else if (this.htmlOption === 'nunjucks') {
-    this.template('module.nunjucks', this.moduleFile + '.nunjucks');
-    this.template('module.js', this.moduleFile + '.js');
-    if (this.jsPreprocessor === 'none') {
-      this.template('module.test.js', this.testFile + '.test.js');
-    }
-    else {
-      this.template('module.test.es6.js', this.testFile + '.test.js');
-    }
-  }
+  var htmlSuffix = (this.htmlOption === 'jade') ? '.jade' : '.nunjucks';
+  var jsSuffix = (this.jsPreprocessor === 'none') ? '.js' : '.es6.js';
+  var cssSuffix = _getCssSuffix(this.cssOption, this.sassSyntax);
 
-  if (this.cssOption === 'sass') {
-    if (this.sassSyntax === 'sass') {
-      this.template('module.css', this.moduleFile + '.sass');
-    }
-    else {
-      this.template('module.css', this.moduleFile + '.scss');
-    }
-  }
-  else if (this.cssOption === 'less') {
-    this.template('module.css', this.moduleFile + '.less');
-  }
-  else if (this.cssOption === 'stylus') {
-    this.template('module.css', this.moduleFile + '.styl');
+  this.template(('module' + htmlSuffix), (this.moduleFile + htmlSuffix));
+  this.template(('module' + jsSuffix), (this.moduleFile + '.js'));
+  this.template(('module.test' + jsSuffix), (this.testFile + '.test.js'));
+  this.template(('module.css'), (this.moduleFile + cssSuffix));
+
+  function _getCssSuffix(cssOption, sassSyntax) {
+    var sassSuffix = (sassSyntax === 'sass') ? '.sass' : '.scss'
+
+    var _result = '.less';
+    _result = (cssOption === 'sass') ? sassSuffix : _result;
+    _result = (cssOption === 'stylus') ? '.styl' : _result;
+
+    return _result;
   }
 };

--- a/module/templates/module.test.es6.js
+++ b/module/templates/module.test.es6.js
@@ -1,7 +1,7 @@
 <% if (testFramework === 'mocha') { %>/*eslint no-unused-expressions:0 */
 <% } %>'use strict';
 
-import <%= _.classify(name) %> from '../<%= _.slugify(name.toLowerCase()) %>';
+import <%= _.classify(name) %> from '../<%= name %>';
 
 describe('<%= _.classify(name) %> View', function() {
 

--- a/module/templates/module.test.js
+++ b/module/templates/module.test.js
@@ -1,7 +1,7 @@
 <% if (testFramework === 'mocha') { %>/*eslint no-unused-expressions:0 */
 <% } %>'use strict';
 
-var <%= _.classify(name) %> = require('../<%= _.slugify(name.toLowerCase()) %>');
+var <%= _.classify(name) %> = require('../<%= name %>');
 
 describe('<%= _.classify(name) %> View', function() {
 


### PR DESCRIPTION
This pull request should fix the following 2 issues:
- Creating a module named `my_module`,  `my_module.test.js` has
```
import MyModule from '../my-module';
```

instead of 
```
import MyModule from '../my_module';
```

- Setting ` "jsPreprocessor": "es6"` , **module.test.js** is selected instead of `module.test.es6.js`.
